### PR TITLE
Post-build Actions of subsequent builds blocked

### DIFF
--- a/src/main/java/hudson/plugins/templateproject/ProxyPublisher.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyPublisher.java
@@ -40,7 +40,7 @@ public class ProxyPublisher extends Recorder {
 	}
 
 	public BuildStepMonitor getRequiredMonitorService() {
-		return BuildStepMonitor.STEP;
+		return BuildStepMonitor.NONE;
 	}
 
 	@Override


### PR DESCRIPTION
If one build is block because of external tool for instance, all
subsequent builds of that project will be blocked, even if those are
running on another slaves