### PR TITLE
Links to template jobs

### DIFF
--- a/src/main/java/hudson/plugins/templateproject/ProxyBuilder.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyBuilder.java
@@ -53,11 +53,7 @@ public class ProxyBuilder extends Builder implements DependecyDeclarer {
 		AbstractProject p = (AbstractProject) Hudson.getInstance().getItemByFullName(projectName);
 		if (p instanceof Project) return ((Project)p).getBuilders();
 		else if (p instanceof MatrixProject) return ((MatrixProject)p).getBuilders();
-<<<<<<< HEAD
-				else return Collections.emptyList();
-=======
 		else return Collections.emptyList();
->>>>>>> 937ccb448507bef799c775badb4a4e2c9514da33
 	}
 
 	@Override

--- a/src/main/java/hudson/plugins/templateproject/ProxyBuilder.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyBuilder.java
@@ -36,6 +36,10 @@ public class ProxyBuilder extends Builder {
 		return projectName;
 	}
 
+    public Item getJob() {
+        return Hudson.getInstance().getItemByFullName(getProjectName(), Item.class);
+    }
+    
 	public List<Builder> getProjectBuilders() {
 		AbstractProject p = (AbstractProject) Hudson.getInstance().getItem(projectName);
 		if (p instanceof Project) return ((Project)p).getBuilders();

--- a/src/main/java/hudson/plugins/templateproject/ProxyBuilder.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyBuilder.java
@@ -36,15 +36,15 @@ public class ProxyBuilder extends Builder {
 		return projectName;
 	}
 
-    public Item getJob() {
-        return Hudson.getInstance().getItemByFullName(getProjectName(), Item.class);
-    }
-    
+	public Item getJob() {
+		return Hudson.getInstance().getItemByFullName(getProjectName(), Item.class);
+	}
+
 	public List<Builder> getProjectBuilders() {
 		AbstractProject p = (AbstractProject) Hudson.getInstance().getItem(projectName);
 		if (p instanceof Project) return ((Project)p).getBuilders();
 		else if (p instanceof MatrixProject) return ((MatrixProject)p).getBuilders();
-                else return Collections.emptyList();
+				else return Collections.emptyList();
 	}
 
 	@Extension

--- a/src/main/java/hudson/plugins/templateproject/ProxyPublisher.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyPublisher.java
@@ -34,10 +34,10 @@ public class ProxyPublisher extends Recorder {
 		return projectName;
 	}
 
-    public Item getJob() {
-        return Hudson.getInstance().getItemByFullName(getProjectName(), Item.class);
-    }
-    
+	public Item getJob() {
+		return Hudson.getInstance().getItemByFullName(getProjectName(), Item.class);
+	}
+
 	public AbstractProject<?, ?> getProject() {
 		return (AbstractProject<?, ?>) Hudson.getInstance()
 				.getItem(projectName);

--- a/src/main/java/hudson/plugins/templateproject/ProxyPublisher.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyPublisher.java
@@ -34,6 +34,10 @@ public class ProxyPublisher extends Recorder {
 		return projectName;
 	}
 
+    public Item getJob() {
+        return Hudson.getInstance().getItemByFullName(getProjectName(), Item.class);
+    }
+    
 	public AbstractProject<?, ?> getProject() {
 		return (AbstractProject<?, ?>) Hudson.getInstance()
 				.getItem(projectName);

--- a/src/main/java/hudson/plugins/templateproject/ProxySCM.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxySCM.java
@@ -40,10 +40,10 @@ public class ProxySCM extends SCM {
 		return projectName;
 	}
 
-    public Item getJob() {
-        return Hudson.getInstance().getItemByFullName(getProjectName(), Item.class);
-    }
-    
+	public Item getJob() {
+		return Hudson.getInstance().getItemByFullName(getProjectName(), Item.class);
+	}
+
 	public AbstractProject<?, ?> getProject() {
 		return (AbstractProject<?, ?>) Hudson.getInstance()
 				.getItem(projectName);
@@ -133,17 +133,17 @@ public class ProxySCM extends SCM {
 		return getProject().getScm().supportsPolling();
 	}
 
-    @Override
-    public SCMRevisionState calcRevisionsFromBuild(AbstractBuild<?, ?> paramAbstractBuild, Launcher paramLauncher, TaskListener paramTaskListener) throws IOException, InterruptedException {
-        return getProject().getScm().calcRevisionsFromBuild(paramAbstractBuild, paramLauncher, paramTaskListener);
-    }
+	@Override
+	public SCMRevisionState calcRevisionsFromBuild(AbstractBuild<?, ?> paramAbstractBuild, Launcher paramLauncher, TaskListener paramTaskListener) throws IOException, InterruptedException {
+		return getProject().getScm().calcRevisionsFromBuild(paramAbstractBuild, paramLauncher, paramTaskListener);
+	}
 
 
-    @Override
-    protected PollingResult compareRemoteRevisionWith(AbstractProject<?, ?> project, Launcher launcher, FilePath workspace, TaskListener listener, SCMRevisionState baseline)
-            throws IOException, InterruptedException {
-            return getProject().getScm().poll(project, launcher, workspace, listener, baseline);
+	@Override
+	protected PollingResult compareRemoteRevisionWith(AbstractProject<?, ?> project, Launcher launcher, FilePath workspace, TaskListener listener, SCMRevisionState baseline)
+			throws IOException, InterruptedException {
+			return getProject().getScm().poll(project, launcher, workspace, listener, baseline);
 
-    }
+	}
 
 }

--- a/src/main/java/hudson/plugins/templateproject/ProxySCM.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxySCM.java
@@ -40,6 +40,10 @@ public class ProxySCM extends SCM {
 		return projectName;
 	}
 
+    public Item getJob() {
+        return Hudson.getInstance().getItemByFullName(getProjectName(), Item.class);
+    }
+    
 	public AbstractProject<?, ?> getProject() {
 		return (AbstractProject<?, ?>) Hudson.getInstance()
 				.getItem(projectName);

--- a/src/main/resources/hudson/plugins/templateproject/ProxyBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/templateproject/ProxyBuilder/config.jelly
@@ -2,5 +2,6 @@
     <f:entry title="${%Template Project}"
              description="Use all the builders from this project.">
         <f:editableComboBox field="projectName" items="${app.topLevelItemNames}" />
+        <t:jobLink job="${instance.job}" />
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/templateproject/ProxyPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/templateproject/ProxyPublisher/config.jelly
@@ -2,5 +2,6 @@
     <f:entry title="${%Template Project}"
              description="Use all the publishers from this project.">
         <f:editableComboBox field="projectName" items="${app.topLevelItemNames}" />
+        <t:jobLink job="${instance.job}" />
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/templateproject/ProxySCM/config.jelly
+++ b/src/main/resources/hudson/plugins/templateproject/ProxySCM/config.jelly
@@ -2,5 +2,6 @@
     <f:entry title="${%Template Project}"
              description="Use all SCM settings from this project.">
         <f:editableComboBox field="projectName" items="${app.topLevelItemNames}" />
+        <t:jobLink job="${instance.job}" />
     </f:entry>
 </j:jelly>


### PR DESCRIPTION
It would be much easier to administer jobs if there was a link to the configure page of the template job from where the template is referred. This patch puts a link to the template job next to the text field where the template name is entered, for easy access to template configuration/viewing.