### PR TITLE
Inserting link to configure template being executed in build log

### DIFF
--- a/src/main/java/hudson/plugins/templateproject/ProxyBuilder.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyBuilder.java
@@ -89,14 +89,14 @@ public class ProxyBuilder extends Builder {
 			if (!builder.perform(build, launcher, listener)) {
 				return false;
 			}
-        String URLConfigureTemplate;
+        String URLTemplateLink;
+        listener.getLogger().println("Starting template job: " + getProjectName());
         if (Jenkins.getInstance().getRootUrl() == null){
-            listener.getLogger().println("Starting template job: " + getProjectName());
             listener.getLogger().println("Could not get URL from configuration, change URL settings in \"Manage Jenkins->Configure System\"");
             listener.getLogger().println("If you set this a link to the configuration of the template job will be displayed instead");
         } else {
-            URLConfigureTemplate = Jenkins.getInstance().getRootUrl() + "job/" + getProjectName() + "/configure";
-            listener.getLogger().println(URLConfigureTemplate);
+            URLTemplateLink = Jenkins.getInstance().getRootUrl() + "job/" + getProjectName();
+            listener.getLogger().println(URLTemplateLink);
         }
 	}
 		return true;

--- a/src/main/java/hudson/plugins/templateproject/ProxyBuilder.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyBuilder.java
@@ -17,6 +17,8 @@ import hudson.tasks.Messages;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
 
+import jenkins.model.Jenkins;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -87,7 +89,16 @@ public class ProxyBuilder extends Builder {
 			if (!builder.perform(build, launcher, listener)) {
 				return false;
 			}
-		}
+        String URLConfigureTemplate;
+        if (Jenkins.getInstance().getRootUrl() == null){
+            listener.getLogger().println("Starting template job: " + getProjectName());
+            listener.getLogger().println("Could not get URL from configuration, change URL settings in \"Manage Jenkins->Configure System\"");
+            listener.getLogger().println("If you set this a link to the configuration of the template job will be displayed instead");
+        } else {
+            URLConfigureTemplate = Jenkins.getInstance().getRootUrl() + "job/" + getProjectName() + "/configure";
+            listener.getLogger().println(URLConfigureTemplate);
+        }
+	}
 		return true;
 	}
 


### PR DESCRIPTION
when debugging  build jobs that is using templates, it has often been difficult tracking down which templates is executing which steps in the build log.
By adding a link to the configure page of the job being executed the debugger can easely see the which template is being executed and can easely jump to the configuration page of the template job for changing the template if nessecary.