### PR TITLE
Corrected performance issue in validation of SCM project.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,21 @@
         </plugins>
      </pluginManagement>
   </build>
-
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>commons-lang</groupId>
+        <artifactId>commons-lang</artifactId>
+        <version>2.4</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>
+  </dependencies>
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/template-project-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/template-project-plugin.git</developerConnection>

--- a/src/main/java/hudson/plugins/templateproject/ProxySCM.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxySCM.java
@@ -23,6 +23,7 @@ import hudson.util.FormValidation;
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -83,12 +84,15 @@ public class ProxySCM extends SCM {
 		public FormValidation doCheckProjectName(@AncestorInPath AccessControlled anc, @QueryParameter String value) {
 			// Require CONFIGURE permission on this project
 			if (!anc.hasPermission(Item.CONFIGURE)) return FormValidation.ok();
-			Item item = Hudson.getInstance().getItemByFullName(
-					value, Item.class);
-			if (item == null) {
+            //this check is important because otherwise plugin will check for similar project which impacts performance
+            //the check will be performed even if this plugin is not used as SCM for the current project
+            if(StringUtils.isEmpty(value)) {
+                return FormValidation.error("Project cannot be empty");
+            }
+            Item item = Hudson.getInstance().getItemByFullName(value, Item.class);
+            if (item == null) {
 				return FormValidation.error(Messages.BuildTrigger_NoSuchProject(value,
-						AbstractProject.findNearest(value)
-								.getName()));
+						AbstractProject.findNearest(value).getName()));
 			}
 			if (!(item instanceof AbstractProject)) {
 				return FormValidation.error(Messages.BuildTrigger_NotBuildable(value));


### PR DESCRIPTION
Because we have lots of jobs in our Jenkins instance (>3000) this fix is pretty important for us.

Jenkins sends validation requests each time a configuration page is opened
in case the field is empty. In case of 'Use SCM from another project' even
if the option wasn't chosen (let's say Git was enabled or None), Jenkins
anyway will send validation request.

In the `doCheckProjectName()` if the Project isn't found, then similar projects
are looked up. And if there are a lot of jobs (let's say 5000), then this is
an additional load. This fix resolves the problem by checking whether the
project name is emtpy first and if so, no similar Project is looked up.

Additionally added an explicit declaration of commons-lang since it was
present only as a transitive dependency which is fragile if we use its
classes.
