### PR TITLE
Fix proposal for JENKINS-23710 - Add support for DependencyDeclarer interface 

### DIFF
--- a/src/main/java/hudson/plugins/templateproject/ProxyBuilder.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyBuilder.java
@@ -7,6 +7,8 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.BuildListener;
+import hudson.model.DependecyDeclarer;
+import hudson.model.DependencyGraph;
 import hudson.model.Hudson;
 import hudson.model.Item;
 import hudson.model.Project;
@@ -27,7 +29,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
-public class ProxyBuilder extends Builder {
+public class ProxyBuilder extends Builder implements DependecyDeclarer {
 
 	private final String projectName;
 
@@ -47,6 +49,19 @@ public class ProxyBuilder extends Builder {
                 else return Collections.emptyList();
 	}
 
+	@Override
+	public void buildDependencyGraph(AbstractProject project, DependencyGraph graph) {
+		AbstractProject<?, ?> templateProject = (AbstractProject) Hudson.getInstance().getItem(getProjectName());
+		if (templateProject != null) {
+			for (Publisher publisher : templateProject.getPublishersList().toList()) {
+				if (publisher instanceof DependecyDeclarer) {
+					((DependecyDeclarer)publisher).buildDependencyGraph(project, graph);
+				}
+			}
+		}
+	}
+
+	
 	@Extension
 	public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
 

--- a/src/main/java/hudson/plugins/templateproject/ProxyPublisher.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyPublisher.java
@@ -11,6 +11,8 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.BuildListener;
+import hudson.model.DependecyDeclarer;
+import hudson.model.DependencyGraph;
 import hudson.model.Hudson;
 import hudson.model.Item;
 import hudson.security.AccessControlled;
@@ -25,7 +27,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
-public class ProxyPublisher extends Recorder {
+public class ProxyPublisher extends Recorder implements DependecyDeclarer {
 
 	private final String projectName;
 
@@ -84,6 +86,22 @@ public class ProxyPublisher extends Recorder {
 			}
 		}
 		return actions;
+	}
+
+	/**
+	 * Any of the publisher could support the DependecyDeclarer interface,
+	 *  so proxy will handle it as well.
+	 *  {@inheritDoc} 
+	 */
+	public void buildDependencyGraph(AbstractProject project, DependencyGraph graph) {
+		AbstractProject<?, ?> templateProject = getProject();
+		if (templateProject != null) {
+			for (Publisher publisher : templateProject.getPublishersList().toList()) {
+				if (publisher instanceof DependecyDeclarer) {
+					((DependecyDeclarer)publisher).buildDependencyGraph(project, graph);
+				}
+			}
+		}
 	}
 
 	@Extension


### PR DESCRIPTION
At the moment the ProxyBuilder and ProxyPublisher do not support the DependencyDeclarer interface, which means plugin implementing it will not behave properly when used from a template, like the parametrized build trigger plugin.

https://issues.jenkins-ci.org/browse/JENKINS-23710
