### PR TITLE
[FIXED JENKINS-15066] Switch to BuildStepMonitor.NONE for ProxyPublisher

### DIFF
--- a/src/main/java/hudson/plugins/templateproject/ProxyPublisher.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyPublisher.java
@@ -46,7 +46,7 @@ public class ProxyPublisher extends Recorder implements DependecyDeclarer {
 	}
 
 	public BuildStepMonitor getRequiredMonitorService() {
-		return BuildStepMonitor.STEP;
+		return BuildStepMonitor.NONE;
 	}
 
 	@Override


### PR DESCRIPTION
[JENKINS-15066](https://issues.jenkins-ci.org/browse/JENKINS-15066)

Otherwise when running concurrent builds many of these builds may wind up waiting for earlier builds to run their publishers, even when this is irrelevant (for example for `ArtifactArchiver`).

This publisher _might_ be delegating to a concrete publisher which _does_ use checkpoints (though generally we are moving away from this in favor of just making build steps behave sanely without blocking in concurrent builds). But in that case, the concrete publisher ought to be blocking on its own checkpoint anyway. So in no case does it make sense for `ProxyPublisher` itself to block.