### PR TITLE
[FIXED JENKINS-24404] added support for build environment variables

### DIFF
--- a/src/main/java/hudson/plugins/templateproject/ProxySCM.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxySCM.java
@@ -132,6 +132,10 @@ public class ProxySCM extends SCM {
 	public boolean supportsPolling() {
 		return getProject().getScm().supportsPolling();
 	}
+	@Override
+	public void buildEnvVars(AbstractBuild<?, ?> build, java.util.Map<String, String> env) {
+		getProject().getScm().buildEnvVars(build, env);
+	}
 
     @Override
     public SCMRevisionState calcRevisionsFromBuild(AbstractBuild<?, ?> paramAbstractBuild, Launcher paramLauncher, TaskListener paramTaskListener) throws IOException, InterruptedException {


### PR DESCRIPTION
Added support for build environment variables, required for git to be able to set the GIT_BRANCH, GIT_URL and GIT_COMMIT environment variables, fixes issue <a href="https://issues.jenkins-ci.org/browse/JENKINS-24404">JENKINS-24404</a>