### PR TITLE
Add proxied build environment

### DIFF
--- a/src/main/java/hudson/plugins/templateproject/ItemListenerImpl.java
+++ b/src/main/java/hudson/plugins/templateproject/ItemListenerImpl.java
@@ -10,17 +10,18 @@ import hudson.model.Project;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.listeners.ItemListener;
+import hudson.tasks.BuildWrapper;
 import hudson.tasks.Builder;
 import java.util.logging.Logger;
 
 /**
- * This ItemListener implementation will force job using 
- * template for publisher to regenerate the transient actions list.  
- * 
- * To do so we use the {@link UpdateTransientProperty} property which does not do 
+ * This ItemListener implementation will force job using
+ * template for publisher to regenerate the transient actions list.
+ *
+ * To do so we use the {@link UpdateTransientProperty} property which does not do
  * anything. This is a bit a hack that relies on the behavior, but
  * there does not seem to be any better way to force updating projects transients actions.
- * 
+ *
  * @author william.bernardet@gmail.com
  *
  */
@@ -36,7 +37,8 @@ public class ItemListenerImpl extends ItemListener {
 	public void onLoaded() {
 		for (AbstractProject<?,?> project : Hudson.getInstance().getAllItems(AbstractProject.class)) {
 			if (project.getPublishersList().get(ProxyPublisher.class) != null ||
-					hasBuilder(project, ProxyBuilder.class)) {
+					hasBuilder(project, ProxyBuilder.class)
+					|| hasBuildWrappers(project, ProxyBuildEnvironment.class)) {
 				try {
 					project.addProperty(new UpdateTransientProperty());
 					project.removeProperty(UpdateTransientProperty.class);
@@ -56,7 +58,17 @@ public class ItemListenerImpl extends ItemListener {
 			return Collections.emptyList();
 		}
 	}
-	
+
+	 private List<BuildWrapper> getBuildWrappers(AbstractProject<?, ?> project) {
+		if (project instanceof Project) {
+			return ((Project)project).getBuildWrappersList();
+		} else if (project instanceof MatrixProject) {
+			return ((MatrixProject)project).getBuildWrappersList();
+		} else {
+			return Collections.emptyList();
+		}
+	}
+
 	public <T> boolean hasBuilder(AbstractProject<?, ?> project, Class<T> type) {
 		for (Builder b : getBuilders(project)) {
 			if (type.isInstance(b)) {
@@ -64,5 +76,14 @@ public class ItemListenerImpl extends ItemListener {
 			}
 		}
 		return false;
-	}	
+	}
+
+	 public <T> boolean hasBuildWrappers(AbstractProject<?, ?> project, Class<T> type) {
+		for (BuildWrapper b : getBuildWrappers(project)) {
+			if (type.isInstance(b)) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/src/main/java/hudson/plugins/templateproject/ProxyBuildEnvironment.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyBuildEnvironment.java
@@ -1,0 +1,160 @@
+package hudson.plugins.templateproject;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.matrix.MatrixProject;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.BuildListener;
+import jenkins.model.DependencyDeclarer;
+import hudson.model.DependencyGraph;
+import hudson.model.Hudson;
+import hudson.model.Item;
+import hudson.model.Project;
+import hudson.model.Run;
+import hudson.security.AccessControlled;
+import hudson.tasks.BuildWrapper;
+import hudson.tasks.BuildWrapperDescriptor;
+import hudson.tasks.Messages;
+import hudson.util.FormValidation;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+public class ProxyBuildEnvironment extends BuildWrapper implements DependencyDeclarer {
+
+  private final String projectName;
+
+  @DataBoundConstructor
+  public ProxyBuildEnvironment(String projectName) {
+    this.projectName = projectName;
+  }
+
+  public String getProjectName() {
+    return projectName;
+  }
+
+  public Item getJob() {
+    return Hudson.getInstance().getItemByFullName(getProjectName(), Item.class);
+  }
+
+  public List<BuildWrapper> getProjectBuildWrappers() {
+    AbstractProject p = (AbstractProject) Hudson.getInstance().getItemByFullName(projectName);
+    if (p instanceof Project) {
+      return ((Project) p).getBuildWrappersList();
+    } else if (p instanceof MatrixProject) {
+      return ((MatrixProject) p).getBuildWrappersList();
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
+  @Override
+  public final void buildDependencyGraph(
+          final AbstractProject project, final DependencyGraph graph) {
+    final Item item = Hudson.getInstance().getItemByFullName(getProjectName());
+    if (item instanceof Project) {
+      for (BuildWrapper wrapper : getProjectBuildWrappers()) {
+        if (wrapper instanceof DependencyDeclarer) {
+          ((DependencyDeclarer) wrapper).buildDependencyGraph(project, graph);
+        }
+      }
+    }
+  }
+
+  @Override
+  public Environment setUp(@SuppressWarnings("rawtypes") AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException,
+          InterruptedException {
+
+    listener.getLogger().println("[TemplateProject] Getting environment from: '" + getProjectName() + "'");
+    for (BuildWrapper builder : getProjectBuildWrappers()) {
+      builder.setUp(build, launcher, listener);
+    }
+    listener.getLogger().println("[TemplateProject] Successfully setup environment from: '" + getProjectName() + "'");
+
+    return new Environment() {
+      @Override
+      public boolean tearDown(@SuppressWarnings("rawtypes") AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
+        // let build continue
+        return true;
+      }
+    };
+  }
+
+  @Override
+  public void preCheckout(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
+    for (BuildWrapper builder : getProjectBuildWrappers()) {
+      builder.preCheckout(build, launcher, listener);
+    }
+  }
+
+  @Override
+  public Launcher decorateLauncher(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException, Run.RunnerAbortedException {
+    for (BuildWrapper builder : getProjectBuildWrappers()) {
+      launcher = builder.decorateLauncher(build, launcher, listener);
+    }
+    return launcher;
+  }
+
+  @Override
+  public OutputStream decorateLogger(AbstractBuild build, OutputStream logger) throws IOException, InterruptedException, Run.RunnerAbortedException {
+    for (BuildWrapper builder : getProjectBuildWrappers()) {
+      logger = builder.decorateLogger(build, logger);
+    }
+    return logger;
+  }
+
+  @Extension
+  public static class DescriptorImpl extends BuildWrapperDescriptor {
+
+    @Override
+    public String getDisplayName() {
+      return "Use build environment from another project";
+    }
+
+    @Override
+    public boolean isApplicable(AbstractProject<?, ?> jobType) {
+      return true;
+    }
+
+    /**
+     * Form validation method.
+     */
+    public FormValidation doCheckProjectName(@AncestorInPath AccessControlled anc, @QueryParameter String value) {
+      // Require CONFIGURE permission on this project
+      if (!anc.hasPermission(Item.CONFIGURE)) {
+        return FormValidation.ok();
+      }
+      Item item = Hudson.getInstance().getItemByFullName(
+              value, Item.class);
+      if (item == null) {
+        return FormValidation.error(Messages.BuildTrigger_NoSuchProject(value,
+                AbstractProject.findNearest(value)
+                .getName()));
+      }
+      if (!(item instanceof Project) && !(item instanceof MatrixProject)) {
+        return FormValidation.error(Messages.BuildTrigger_NotBuildable(value));
+      }
+      return FormValidation.ok();
+    }
+  }
+
+  @Override
+  public Collection<? extends Action> getProjectActions(AbstractProject project) {
+    List<Action> actions = new ArrayList<Action>();
+    for (BuildWrapper wrapper : getProjectBuildWrappers()) {
+      actions.addAll(wrapper.getProjectActions(project));
+    }
+    return actions;
+  }
+
+}

--- a/src/main/java/hudson/plugins/templateproject/ProxyBuildEnvironment.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyBuildEnvironment.java
@@ -32,129 +32,129 @@ import org.kohsuke.stapler.QueryParameter;
 
 public class ProxyBuildEnvironment extends BuildWrapper implements DependencyDeclarer {
 
-  private final String projectName;
+	private final String projectName;
 
-  @DataBoundConstructor
-  public ProxyBuildEnvironment(String projectName) {
-    this.projectName = projectName;
-  }
+	@DataBoundConstructor
+	public ProxyBuildEnvironment(String projectName) {
+		this.projectName = projectName;
+	}
 
-  public String getProjectName() {
-    return projectName;
-  }
+	public String getProjectName() {
+		return projectName;
+	}
 
-  public Item getJob() {
-    return Hudson.getInstance().getItemByFullName(getProjectName(), Item.class);
-  }
+	public Item getJob() {
+		return Hudson.getInstance().getItemByFullName(getProjectName(), Item.class);
+	}
 
-  public List<BuildWrapper> getProjectBuildWrappers() {
-    AbstractProject p = (AbstractProject) Hudson.getInstance().getItemByFullName(projectName);
-    if (p instanceof Project) {
-      return ((Project) p).getBuildWrappersList();
-    } else if (p instanceof MatrixProject) {
-      return ((MatrixProject) p).getBuildWrappersList();
-    } else {
-      return Collections.emptyList();
-    }
-  }
+	public List<BuildWrapper> getProjectBuildWrappers() {
+		AbstractProject p = (AbstractProject) Hudson.getInstance().getItemByFullName(projectName);
+		if (p instanceof Project) {
+			return ((Project) p).getBuildWrappersList();
+		} else if (p instanceof MatrixProject) {
+			return ((MatrixProject) p).getBuildWrappersList();
+		} else {
+			return Collections.emptyList();
+		}
+	}
 
-  @Override
-  public final void buildDependencyGraph(
-          final AbstractProject project, final DependencyGraph graph) {
-    final Item item = Hudson.getInstance().getItemByFullName(getProjectName());
-    if (item instanceof Project) {
-      for (BuildWrapper wrapper : getProjectBuildWrappers()) {
-        if (wrapper instanceof DependencyDeclarer) {
-          ((DependencyDeclarer) wrapper).buildDependencyGraph(project, graph);
-        }
-      }
-    }
-  }
+	@Override
+	public final void buildDependencyGraph(
+					final AbstractProject project, final DependencyGraph graph) {
+		final Item item = Hudson.getInstance().getItemByFullName(getProjectName());
+		if (item instanceof Project) {
+			for (BuildWrapper wrapper : getProjectBuildWrappers()) {
+				if (wrapper instanceof DependencyDeclarer) {
+					((DependencyDeclarer) wrapper).buildDependencyGraph(project, graph);
+				}
+			}
+		}
+	}
 
-  @Override
-  public Environment setUp(@SuppressWarnings("rawtypes") AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException,
-          InterruptedException {
+	@Override
+	public Environment setUp(@SuppressWarnings("rawtypes") AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException,
+					InterruptedException {
 
-    listener.getLogger().println("[TemplateProject] Getting environment from: '" + getProjectName() + "'");
-    for (BuildWrapper builder : getProjectBuildWrappers()) {
-      builder.setUp(build, launcher, listener);
-    }
-    listener.getLogger().println("[TemplateProject] Successfully setup environment from: '" + getProjectName() + "'");
+		listener.getLogger().println("[TemplateProject] Getting environment from: '" + getProjectName() + "'");
+		for (BuildWrapper builder : getProjectBuildWrappers()) {
+			builder.setUp(build, launcher, listener);
+		}
+		listener.getLogger().println("[TemplateProject] Successfully setup environment from: '" + getProjectName() + "'");
 
-    return new Environment() {
-      @Override
-      public boolean tearDown(@SuppressWarnings("rawtypes") AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
-        // let build continue
-        return true;
-      }
-    };
-  }
+		return new Environment() {
+			@Override
+			public boolean tearDown(@SuppressWarnings("rawtypes") AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
+				// let build continue
+				return true;
+			}
+		};
+	}
 
-  @Override
-  public void preCheckout(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
-    for (BuildWrapper builder : getProjectBuildWrappers()) {
-      builder.preCheckout(build, launcher, listener);
-    }
-  }
+	@Override
+	public void preCheckout(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
+		for (BuildWrapper builder : getProjectBuildWrappers()) {
+			builder.preCheckout(build, launcher, listener);
+		}
+	}
 
-  @Override
-  public Launcher decorateLauncher(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException, Run.RunnerAbortedException {
-    for (BuildWrapper builder : getProjectBuildWrappers()) {
-      launcher = builder.decorateLauncher(build, launcher, listener);
-    }
-    return launcher;
-  }
+	@Override
+	public Launcher decorateLauncher(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException, Run.RunnerAbortedException {
+		for (BuildWrapper builder : getProjectBuildWrappers()) {
+			launcher = builder.decorateLauncher(build, launcher, listener);
+		}
+		return launcher;
+	}
 
-  @Override
-  public OutputStream decorateLogger(AbstractBuild build, OutputStream logger) throws IOException, InterruptedException, Run.RunnerAbortedException {
-    for (BuildWrapper builder : getProjectBuildWrappers()) {
-      logger = builder.decorateLogger(build, logger);
-    }
-    return logger;
-  }
+	@Override
+	public OutputStream decorateLogger(AbstractBuild build, OutputStream logger) throws IOException, InterruptedException, Run.RunnerAbortedException {
+		for (BuildWrapper builder : getProjectBuildWrappers()) {
+			logger = builder.decorateLogger(build, logger);
+		}
+		return logger;
+	}
 
-  @Extension
-  public static class DescriptorImpl extends BuildWrapperDescriptor {
+	@Extension
+	public static class DescriptorImpl extends BuildWrapperDescriptor {
 
-    @Override
-    public String getDisplayName() {
-      return "Use build environment from another project";
-    }
+		@Override
+		public String getDisplayName() {
+			return "Use build environment from another project";
+		}
 
-    @Override
-    public boolean isApplicable(AbstractProject<?, ?> jobType) {
-      return true;
-    }
+		@Override
+		public boolean isApplicable(AbstractProject<?, ?> jobType) {
+			return true;
+		}
 
-    /**
-     * Form validation method.
-     */
-    public FormValidation doCheckProjectName(@AncestorInPath AccessControlled anc, @QueryParameter String value) {
-      // Require CONFIGURE permission on this project
-      if (!anc.hasPermission(Item.CONFIGURE)) {
-        return FormValidation.ok();
-      }
-      Item item = Hudson.getInstance().getItemByFullName(
-              value, Item.class);
-      if (item == null) {
-        return FormValidation.error(Messages.BuildTrigger_NoSuchProject(value,
-                AbstractProject.findNearest(value)
-                .getName()));
-      }
-      if (!(item instanceof Project) && !(item instanceof MatrixProject)) {
-        return FormValidation.error(Messages.BuildTrigger_NotBuildable(value));
-      }
-      return FormValidation.ok();
-    }
-  }
+		/**
+		 * Form validation method.
+		 */
+		public FormValidation doCheckProjectName(@AncestorInPath AccessControlled anc, @QueryParameter String value) {
+			// Require CONFIGURE permission on this project
+			if (!anc.hasPermission(Item.CONFIGURE)) {
+				return FormValidation.ok();
+			}
+			Item item = Hudson.getInstance().getItemByFullName(
+							value, Item.class);
+			if (item == null) {
+				return FormValidation.error(Messages.BuildTrigger_NoSuchProject(value,
+								AbstractProject.findNearest(value)
+								.getName()));
+			}
+			if (!(item instanceof Project) && !(item instanceof MatrixProject)) {
+				return FormValidation.error(Messages.BuildTrigger_NotBuildable(value));
+			}
+			return FormValidation.ok();
+		}
+	}
 
-  @Override
-  public Collection<? extends Action> getProjectActions(AbstractProject project) {
-    List<Action> actions = new ArrayList<Action>();
-    for (BuildWrapper wrapper : getProjectBuildWrappers()) {
-      actions.addAll(wrapper.getProjectActions(project));
-    }
-    return actions;
-  }
+	@Override
+	public Collection<? extends Action> getProjectActions(AbstractProject project) {
+		List<Action> actions = new ArrayList<Action>();
+		for (BuildWrapper wrapper : getProjectBuildWrappers()) {
+			actions.addAll(wrapper.getProjectActions(project));
+		}
+		return actions;
+	}
 
 }

--- a/src/main/resources/hudson/plugins/templateproject/ProxyBuildEnvironment/config.jelly
+++ b/src/main/resources/hudson/plugins/templateproject/ProxyBuildEnvironment/config.jelly
@@ -1,0 +1,7 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="${%Template Project}"
+             description="Use all the build Wrappers from this project.">
+        <f:editableComboBox field="projectName" items="${app.topLevelItemNames}" />
+        <t:jobLink job="${instance.job}" />
+    </f:entry>
+</j:jelly>


### PR DESCRIPTION
Update the plugin to support sharing of the Build Environment.   Currently supports all build wrappers except injecting protected environment variables such as passwords.

Update the base jenkins version to a more recent version, 1.609 which is the base for the most recent LTS.

Update the ProxySCM to handle some cases where the template project or the SCM configuration on the template project is null resulting in odd behaviours when trying syncing and polling using templates.

Change-Id: I067d38ee89370187dd6a73e795705117e3a13e30