### PR TITLE
[JENKINS-21276] make template project plugin always perform every post-build step

### DIFF
--- a/src/main/java/hudson/plugins/templateproject/ProxyPublisher.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyPublisher.java
@@ -73,15 +73,17 @@ public class ProxyPublisher extends Recorder implements DependecyDeclarer {
 	@Override
 	public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
 			BuildListener listener) throws InterruptedException, IOException {
+		boolean publishersResult = true;
 		for (Publisher publisher : getProject().getPublishersList().toList()) {
 			listener.getLogger().println("[TemplateProject] Starting publishers from: '" + getProjectName() + "'");
 			if (!publisher.perform(build, launcher, listener)) {
 				listener.getLogger().println("[TemplateProject] FAILED performing publishers from: '" + getProjectName() + "'");
-				return false;
+				publishersResult = false;
+			} else {
+				listener.getLogger().println("[TemplateProject] Successfully performed publishers from: '" + getProjectName() + "'");
 			}
-			listener.getLogger().println("[TemplateProject] Successfully performed publishers from: '" + getProjectName() + "'");
 		}
-		return true;
+		return publishersResult;
 	}
 
 	@Override


### PR DESCRIPTION
This branch contains a fix for bug [JENKINS-21276] by making it so the plugin doesn't stop executing post-build actions from the template project because one of them failed.