### PR TITLE
[JENKINS-39314][JENKINS-39318] Environment variables not exported & tearDown() not called for build environments with "Use build environment from another project".

### DIFF
--- a/src/main/java/hudson/plugins/templateproject/ProxyBuildEnvironment.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyBuildEnvironment.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -84,12 +85,20 @@ public class ProxyBuildEnvironment extends BuildWrapper implements DependencyDec
 
 		AbstractProject p = TemplateUtils.getProject(getProjectName(), build);
 		listener.getLogger().println("[TemplateProject] Getting environment from: " + HyperlinkNote.encodeTo('/'+ p.getUrl(), p.getFullDisplayName()));
+		final ArrayList<Environment> envs = new ArrayList<Environment>();
 		for (BuildWrapper builder : getProjectBuildWrappers(build)) {
-			builder.setUp(build, launcher, listener);
+			envs.add(builder.setUp(build, launcher, listener));
 		}
 		listener.getLogger().println("[TemplateProject] Successfully setup environment from: '" + p.getFullDisplayName() + "'");
 
 		return new Environment() {
+			@Override
+			public void buildEnvVars(Map<String, String> vars) {
+				for (Environment env : envs) {
+					env.buildEnvVars(vars);
+				}
+			}
+
 			@Override
 			public boolean tearDown(@SuppressWarnings("rawtypes") AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
 				// let build continue

--- a/src/main/java/hudson/plugins/templateproject/ProxyBuildEnvironment.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyBuildEnvironment.java
@@ -101,8 +101,11 @@ public class ProxyBuildEnvironment extends BuildWrapper implements DependencyDec
 
 			@Override
 			public boolean tearDown(@SuppressWarnings("rawtypes") AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
-				// let build continue
-				return true;
+				boolean operationSucceeded = true;
+				for (Environment env : envs) {
+					operationSucceeded &= env.tearDown(build, listener);
+				}
+				return operationSucceeded;
 			}
 		};
 	}


### PR DESCRIPTION
- Fixes the existing issue with environment variables set by the build environment template not passing to the `ProxyBuildEnvironment`.
  - Concrete case: using the Android emulator plugin would not work because it sets several ANDROID_\* env variables which would otherwise be discarded.
- Fixes the existing issue with `tearDown()` not being called by the `ProxyBuildEnvironment`. This can cause leaks and also disrupts the way some build environment tools function.
  - Concrete case: The build-timeout plugin uses `tearDown()` to reset internal timers. The Android emulator plugin uses `tearDown()` to clean up certain artifacts.
