### PR TITLE
[JENKINS-39314] Fix env vars set in other build environments not being passed to the current one.

### DIFF
--- a/src/main/java/hudson/plugins/templateproject/ProxyBuildEnvironment.java
+++ b/src/main/java/hudson/plugins/templateproject/ProxyBuildEnvironment.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -84,12 +85,20 @@ public class ProxyBuildEnvironment extends BuildWrapper implements DependencyDec
 
 		AbstractProject p = TemplateUtils.getProject(getProjectName(), build);
 		listener.getLogger().println("[TemplateProject] Getting environment from: " + HyperlinkNote.encodeTo('/'+ p.getUrl(), p.getFullDisplayName()));
+		final ArrayList<Environment> envs = new ArrayList<Environment>();
 		for (BuildWrapper builder : getProjectBuildWrappers(build)) {
-			builder.setUp(build, launcher, listener);
+			envs.add(builder.setUp(build, launcher, listener));
 		}
 		listener.getLogger().println("[TemplateProject] Successfully setup environment from: '" + p.getFullDisplayName() + "'");
 
 		return new Environment() {
+			@Override
+			public void buildEnvVars(Map<String, String> vars) {
+				for (Environment env : envs) {
+					env.buildEnvVars(vars);
+				}
+			}
+
 			@Override
 			public boolean tearDown(@SuppressWarnings("rawtypes") AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
 				// let build continue


### PR DESCRIPTION
- Fixes the existing issue with environment variables set by the build environment template not passing to the ProxyBuildEnvironment.
  - Concrete case: using the Android emulator plugin would not work because it sets several ANDROID_* env variables which would otherwise be discarded.